### PR TITLE
add newline before alias in .*rc file

### DIFF
--- a/CleanerInstaller.sh
+++ b/CleanerInstaller.sh
@@ -59,7 +59,7 @@ done
 cp -f ./Cleaner_42.sh "$HOME"
 
 if ! grep "alias cclean='bash ~/Cleaner_42.sh'" <"$shell_f" &>/dev/null; then
-	echo "alias cclean='bash ~/Cleaner_42.sh'" >>"$shell_f"
+	echo "\nalias cclean='bash ~/Cleaner_42.sh'" >>"$shell_f"
 fi
 
 if grep "alias cclean='bash ~/Cleaner_42.sh'" <"$shell_f" &>/dev/null && ls "$HOME"/Cleaner_42.sh &>/dev/null; then


### PR DESCRIPTION
I add newline before cclean alias
because sometimes user dont make a newline in last line of .*rc file
and happen like that in last line of .*rc file

```
export gitUser="kirwa-KO"alias cclean='bash ~/Cleaner_42.sh'
```
