### PR TITLE
Update CleanerInstaller.sh

### DIFF
--- a/CleanerInstaller.sh
+++ b/CleanerInstaller.sh
@@ -59,7 +59,8 @@ done
 cp -f ./Cleaner_42.sh "$HOME"
 
 if ! grep "alias cclean='bash ~/Cleaner_42.sh'" <"$shell_f" &>/dev/null; then
-	echo "\nalias cclean='bash ~/Cleaner_42.sh'" >>"$shell_f"
+	echo "" >>"$shell_f"
+	echo "alias cclean='bash ~/Cleaner_42.sh'" >>"$shell_f"
 fi
 
 if grep "alias cclean='bash ~/Cleaner_42.sh'" <"$shell_f" &>/dev/null && ls "$HOME"/Cleaner_42.sh &>/dev/null; then


### PR DESCRIPTION
I remove the \n before alias because in bash the script writes \n doesn't return to the newline

bash make :
```bash
\nalias cclean='bash ~/Cleaner_42.sh'
```
not 
```bash

alias cclean='bash ~/Cleaner_42.sh'
```

so what I did now I add 
echo "" >>"$shell_f"
that make newline in all shells