### PR TITLE
Get more space, less useless files

### DIFF
--- a/Cleaner_42.sh
+++ b/Cleaner_42.sh
@@ -60,14 +60,21 @@ echo -e "\033[31m\n -- Cleaning ...\n\033[0m "
 /bin/rm -rf "$HOME"/Library/Application\ Support/Caches/* &>/dev/null
 
 #Slack, VSCode, Discord and Chrome Caches
+find "$HOME"/Library/Application\ Support/discord/Cache/ -print0 &>/dev/null | xargs -0 rm -rf &>/dev/null
 /bin/rm -rf "$HOME"/Library/Application\ Support/Slack/Service\ Worker/CacheStorage/* &>/dev/null
-/bin/rm -rf "$HOME"/Library/Application\ Support/Code/User/workspaceStorage/* &>/dev/null
+/bin/rm -rf "$HOME"/Library/Application\ Support/Slack/Cache/* &>/dev/null
 /bin/rm -rf "$HOME"/Library/Application\ Support/discord/Cache/* &>/dev/null
 /bin/rm -rf "$HOME"/Library/Application\ Support/discord/Code\ Cache/js* &>/dev/null
+/bin/rm -rf "$HOME"/Library/Application\ Support/discord/Crashpad/completed/*  &>/dev/null
+/bin/rm -rf "$HOME"/Library/Application\ Support/Code/Cache/* &>/dev/null
+/bin/rm -rf "$HOME"/Library/Application\ Support/Code/CachedData/* &>/dev/null
+/bin/rm -rf "$HOME"/Library/Application\ Support/Code/Crashpad/completed/* &>/dev/null
+/bin/rm -rf "$HOME"/Library/Application\ Support/Code/User/workspaceStorage/* &>/dev/null
 /bin/rm -rf "$HOME"/Library/Application\ Support/Google/Chrome/Profile\ [0-9]/Service\ Worker/CacheStorage/* &>/dev/null
 /bin/rm -rf "$HOME"/Library/Application\ Support/Google/Chrome/Default/Service\ Worker/CacheStorage/* &>/dev/null
 /bin/rm -rf "$HOME"/Library/Application\ Support/Google/Chrome/Profile\ [0-9]/Application\ Cache/* &>/dev/null
 /bin/rm -rf "$HOME"/Library/Application\ Support/Google/Chrome/Default/Application\ Cache/* &>/dev/null
+/bin/rm -rf "$HOME"/Library/Application\ Support/Google/Chrome/Crashpad/completed/* &>/dev/null
 
 #.DS_Store files
 find "$HOME"/Desktop -name .DS_Store -depth -exec /bin/rm {} \; &>/dev/null

--- a/Cleaner_42.sh
+++ b/Cleaner_42.sh
@@ -60,7 +60,6 @@ echo -e "\033[31m\n -- Cleaning ...\n\033[0m "
 /bin/rm -rf "$HOME"/Library/Application\ Support/Caches/* &>/dev/null
 
 #Slack, VSCode, Discord and Chrome Caches
-find "$HOME"/Library/Application\ Support/discord/Cache/ -print0 &>/dev/null | xargs -0 rm -rf &>/dev/null
 /bin/rm -rf "$HOME"/Library/Application\ Support/Slack/Service\ Worker/CacheStorage/* &>/dev/null
 /bin/rm -rf "$HOME"/Library/Application\ Support/Slack/Cache/* &>/dev/null
 /bin/rm -rf "$HOME"/Library/Application\ Support/discord/Cache/* &>/dev/null


### PR DESCRIPTION
Because deleting cache is not enough, I found out some more files to be removed mainly in the code folder, as it can get large pretty quickly and they are safe to delete as long as you don't care about fast startups (from my tests i have loads of extensions and still no noticeable difference in startup times).
> We keep that data around to make subsequent startup faster, it's not needed (and can be deleted)
> Cache and CachedData is a folder from Electron / Chromium. Nothing we control currently, but should be free to be deleted between a restart.

Check from here [issue#76546](https://github.com/microsoft/vscode/issues/76546)

Deleting Crashpad files.
> To make Chromium write crash dumps, no additional work is needed. 

It has to do with Chromium based apps such as Discord and Vscode and the way they store crash dumps in the Crashpad/complete folder

Check from [here](https://www.chromium.org/developers/crash-reports/) 

Basically a 300MB~ of removed useless files.

Also added Slack/Cache