### PR TITLE
fix temporary file cleanup to properly handle filenames with spaces a…

### DIFF
--- a/LinuxCleaner_42.sh
+++ b/LinuxCleaner_42.sh
@@ -152,7 +152,7 @@ function clean {
 	clean_glob "$HOME"/.thumbnails/*
 
 	#Temporary files
- 	clean_glob $(find /tmp -type f -user "$USER" 2>/dev/null)
+ 	find /tmp -type f -user "$USER" -exec rm -f {} \; 2>/dev/null
 
 
 	#Things related to pool (piscine)


### PR DESCRIPTION
the temporary file cleanup in LinuxCleaner_42.sh used unquoted command substitution (clean_glob $(find /tmp ...)) which failed on filenames containing spaces or special characters due to improper word splitting

replaced with find -exec command which safely processes each file individually without relying on shell expansion

find /tmp -type f -user "$USER" -exec rm -f {} \; 2>/dev/null

ensures reliable cleanup of all temporary files regardless of filename complexity